### PR TITLE
Upgrade deps to support blocks iterator binary format version 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "blocks_iterator"
-version = "1.0.5"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba655e006030249672e4ea2af57a719a5d2f675d2d87bc462b929d9d4e2b34ef"
+checksum = "59a1fbf1d7af4509aabb0bab32e9b58dd56a4a72d6c27953701b490f8ef9da76"
 dependencies = [
  "bitcoin",
  "bitcoin_slices",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-blocks_iterator = "1.0.5"
+blocks_iterator = "2.0.0"
 env_logger = "0.11.6"
 log = "0.4.22"

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,9 +57,9 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         println!(
             "{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}",
-            block_extra.height,
-            block_extra.block.header.time,
-            block_extra.block.header.nonce,
+            block_extra.height(),
+            block_extra.block().header.time,
+            block_extra.block().header.nonce,
             txno,
             empty,
             p2pk,


### PR DESCRIPTION
blocks iterator 2 change the binary format exchanged https://github.com/RCasatta/blocks_iterator/pull/82, the position of the block size in bytes is put in front, allowing downstream to avoid initializing a Block and use visitor pattern instead to achieve more perfomance.
The improvement is optional and as soon as the first `block_extra.block()` is called the Block is instantiated the performance are the same as before (like in this PR). But a client could avoid the step and operated directly on block_bytes
